### PR TITLE
active storageでavatar画像実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem "active_decorator"
 gem "omniauth"
 gem "omniauth-github"
 gem "dotenv-rails"
+gem "mini_magick"
+
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,7 @@ DEPENDENCIES
   kaminari
   letter_opener
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   omniauth
   omniauth-github
   puma (~> 4.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
 
   protected
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:account_update, keys: [:postcode, :address, :profile, :avatar])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:postcode, :address, :profile, :avatar, :delete_avatar_check])
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,6 @@ class ApplicationController < ActionController::Base
 
   protected
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:account_update, keys: [:postcode, :address, :profile])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:postcode, :address, :profile, :avatar])
     end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -18,6 +18,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   private
     def delete_avatar?
-      !params[:user][:delete_avatar_check].to_i.zero?
+      !account_update_params[:delete_avatar_check].to_i.zero?
     end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  def update
+    super do
+      self.resource.delete_avatar if delete_avatar?
+    end
+  end
+
   protected
     def update_resource(resource, params)
       resource.update_without_password(params)
@@ -8,5 +14,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     def after_update_path_for(resource)
       user_path(resource)
+    end
+
+  private
+    def delete_avatar?
+      !params[:user][:delete_avatar_check].to_i.zero?
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,8 @@ class User < ApplicationRecord
 
   VALID_POSTCODE = /\A\z|\A\d{7}\z/
   validates :postcode, format: { with: VALID_POSTCODE }
-  validates :delete_avatar_check, acceptance: true
 
+  attr_accessor :delete_avatar_check
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable
+  
+  has_one_attached :avatar
 
   VALID_POSTCODE = /\A\z|\A\d{7}\z/
   validates :postcode, format: { with: VALID_POSTCODE }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :omniauthable
-  
+
   has_one_attached :avatar
 
   VALID_POSTCODE = /\A\z|\A\d{7}\z/
@@ -17,5 +17,9 @@ class User < ApplicationRecord
       user.email = auth.info.email
       user.password = Devise.friendly_token[0, 20]
     end
+  end
+
+  def thumbnail
+    avatar.variant(resize: "300x300")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
 
   VALID_POSTCODE = /\A\z|\A\d{7}\z/
   validates :postcode, format: { with: VALID_POSTCODE }
+  validates :delete_avatar_check, acceptance: true
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
@@ -21,5 +22,9 @@ class User < ApplicationRecord
 
   def thumbnail
     avatar.variant(resize: "300x300")
+  end
+
+  def delete_avatar
+    avatar.purge
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -27,6 +27,19 @@
     <%= f.label :avatar %><br />
     <%= f.file_field :avatar%>
   </div>
+ 
+  <% unless @user.avatar.blank? %>
+    <div class="field">
+      <%= t("users.edit.current_avatar") %><br />
+      <%= image_tag @user.thumbnail %>
+    </div>
+
+    <div class="form-group form-inline">
+      <%= f.label :delete_avatar_check, class: "checkbox inline" %><br />
+      <%= f.check_box :delete_avatar_check %>
+    </div>
+  <% end %>
+
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -40,7 +40,6 @@
     </div>
   <% end %>
 
-
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
   <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -23,6 +23,11 @@
     <%= f.text_area :profile, autofocus: true, autocomplete: "profile" %>
   </div>
 
+  <div class="field">
+    <%= f.label :avatar %><br />
+    <%= f.file_field :avatar%>
+  </div>
+
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div><%= t('.currently_waiting_confirmation_for_email', email: resource.unconfirmed_email) %></div>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,5 +9,5 @@
   <dt><%= User.human_attribute_name(:profile) %></dt>
   <dd><%= br_with_escape(@user.complement_blank_text(@user.profile)) %></dd>
   <dt><%= User.human_attribute_name(:avatar) %></dt>
-  <dd><%= image_tag @user.thumbnail %></dd>
+  <dd><%= image_tag @user.thumbnail unless @user.avatar.blank? %></dd>
 </dl>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,5 +9,5 @@
   <dt><%= User.human_attribute_name(:profile) %></dt>
   <dd><%= br_with_escape(@user.complement_blank_text(@user.profile)) %></dd>
   <dt><%= User.human_attribute_name(:avatar) %></dt>
-  <dd><%= image_tag @user.avatar %></dd>
+  <dd><%= image_tag @user.thumbnail %></dd>
 </dl>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,4 +8,6 @@
   <dd><%= @user.complement_blank_text(@user.address) %></dd>
   <dt><%= User.human_attribute_name(:profile) %></dt>
   <dd><%= br_with_escape(@user.complement_blank_text(@user.profile)) %></dd>
+  <dt><%= User.human_attribute_name(:avatar) %></dt>
+  <dd><%= image_tag @user.avatar %></dd>
 </dl>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -259,7 +259,7 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  config.omniauth :github, ENV['GITHUB_ID'], ENV['GITHUB_SECRET'], scope: 'user'
+  config.omniauth :github, ENV["GITHUB_ID"], ENV["GITHUB_SECRET"], scope: "user"
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -1,0 +1,5 @@
+en:
+  activerecord:
+    attributes:
+      user:
+        delete_avatar_check: Delete avatar

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -13,3 +13,4 @@ ja:
         postcode: 郵便番号
         address: 住所
         profile: プロフィール
+        avatar: アバター

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -14,3 +14,4 @@ ja:
         address: 住所
         profile: プロフィール
         avatar: アバター
+        delete_avatar_check: アバターを削除

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -20,7 +20,3 @@ en:
       update: Updated book
     destroy:
       destroy: Deleted book
-
-  users:
-    edit:
-      delete_avatar_check: Delete avatar

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -20,3 +20,7 @@ en:
       update: Updated book
     destroy:
       destroy: Deleted book
+
+  users:
+    edit:
+      delete_avatar_check: Delete avatar

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -27,3 +27,7 @@ ja:
       update: 本を更新しました
     destroy:
       destroy: 本を削除しました
+  
+  users:
+    edit:
+      current_avatar: 現在のアバター

--- a/db/migrate/20191204131616_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20191204131616_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20191204131616_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20191204131616_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_03_084601) do
+ActiveRecord::Schema.define(version: 2019_12_04_131616) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "books", force: :cascade do |t|
     t.string "title"
@@ -39,4 +60,5 @@ ActiveRecord::Schema.define(version: 2019_12_03_084601) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
- editからavatar画像を追加、削除できる機能実装。
- `mini_magick`を使っているため`ImageMagick`が必要　
- 新しい画像選択　→　validationエラー　→　正しい情報で更新
上記でやった場合新しい画像はcacheがないため新しい画像になりません。
active storageだとcache機能がないのでcacheからの画像更新を今回見送りました。